### PR TITLE
add docker daemon configuration

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -1,4 +1,6 @@
 ---
+docker_data_folder: /data/docker
+
 jenkins_config: |
   # https://plugins.jenkins.io/configuration-as-code/
   jenkins:

--- a/files/etc_cron.daily_datagov-docker
+++ b/files/etc_cron.daily_datagov-docker
@@ -6,4 +6,6 @@ set -o nounset
 
 # Clean up unnecessary docker files/images/builds
 
+docker container prune
+docker volume prune
 docker image prune

--- a/handlers/main.yml
+++ b/handlers/main.yml
@@ -8,4 +8,4 @@
 - name: restart docker
   service: name=docker state=restarted
   tags:
-  - molecule-notest
+    - molecule-notest

--- a/handlers/main.yml
+++ b/handlers/main.yml
@@ -7,5 +7,4 @@
 
 - name: restart docker
   service: name=docker state=restarted
-  tags:
-    - molecule-notest
+  when: molecule_test is not defined

--- a/handlers/main.yml
+++ b/handlers/main.yml
@@ -7,3 +7,5 @@
 
 - name: restart docker
   service: name=docker state=restarted
+  tags:
+  - molecule-notest

--- a/handlers/main.yml
+++ b/handlers/main.yml
@@ -4,3 +4,6 @@
 
 - name: reload nginx
   service: name=nginx state=reloaded
+
+- name: restart docker
+  service: name=docker state=restarted

--- a/molecule/default/molecule.yml
+++ b/molecule/default/molecule.yml
@@ -14,6 +14,10 @@ provisioner:
   name: ansible
   lint:
     name: ansible-lint
+  inventory:
+    group_vars:
+      all:
+        molecule_test: true
 verifier:
   name: testinfra
   lint:

--- a/molecule/default/tests/test_default.py
+++ b/molecule/default/tests/test_default.py
@@ -36,3 +36,11 @@ def test_jenkins_credentials(host):
     assert credentials.group == 'root'
     assert credentials.mode == 0o640
     assert credentials.contains('admin:%s' % admin_password)
+
+
+def test_docker_config(host):
+    docker_config = host.file('/etc/docker/daemon.json')
+    assert docker_config.user == 'jenkins'
+    assert docker_config.group == 'jenkins'
+    assert docker_config.mode == 0o640
+    assert docker_config.contains('graph')

--- a/molecule/default/tests/test_default.py
+++ b/molecule/default/tests/test_default.py
@@ -43,4 +43,4 @@ def test_docker_config(host):
     assert docker_config.user == 'jenkins'
     assert docker_config.group == 'jenkins'
     assert docker_config.mode == 0o640
-    assert docker_config.contains('graph')
+    assert docker_config.contains('data-root')

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -71,7 +71,7 @@
   template:
     src: etc_docker_daemon.json
     dest: /etc/docker/daemon.json
-    mode: 0644
+    mode: 0640
     owner: jenkins
     group: jenkins
   notify:

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -67,6 +67,16 @@
   notify:
     - restart jenkins
 
+- name: setup docker configuration
+  template:
+    src: etc_docker_daemon.json
+    dest: /etc/docker/daemon.json
+    mode: 0644
+    owner: root
+    group: root
+  notify:
+    - restart docker
+
 - name: setup jenkins credentials for CLI tasks
   copy:
     dest: /root/jenkins.txt

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -72,8 +72,8 @@
     src: etc_docker_daemon.json
     dest: /etc/docker/daemon.json
     mode: 0644
-    owner: root
-    group: root
+    owner: jenkins
+    group: jenkins
   notify:
     - restart docker
 

--- a/templates/etc_docker_daemon.json
+++ b/templates/etc_docker_daemon.json
@@ -1,3 +1,3 @@
 {
-    "graph": "{{ docker_data_folder }}"
+    "data-root": "{{ docker_data_folder }}"
 }

--- a/templates/etc_docker_daemon.json
+++ b/templates/etc_docker_daemon.json
@@ -1,0 +1,3 @@
+{
+    "graph": "{{ docker_data_folder }}"
+}


### PR DESCRIPTION
Recently [a deploy failed](https://github.com/GSA/datagov-deploy/issues/2626). This was related to the recent rebuild of jenkins and [a manual configuration that was never committed to code](https://github.com/GSA/datagov-deploy/issues/1610).
This adds the configuration to the deployment for later use.